### PR TITLE
Improve primitive object wrapping and refactor PyObject slightly

### DIFF
--- a/src/main/kotlin/interpreter/functions/PrintBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PrintBuiltinFunction.kt
@@ -32,7 +32,7 @@ class PrintBuiltinFunction : PyBuiltinFunction("print") {
         // todo: more args
 
         val args = kwargs["args"] as PyTuple
-        val result = args.subobjects.joinToString(" ") { it.pyRepr().wrappedString }
+        val result = args.subobjects.joinToString(" ") { it.getPyRepr().wrappedString }
 
         println(result)
         return PyNone

--- a/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
@@ -36,8 +36,10 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction(PyBuiltinFunctio
         /**
          * Makes a wrapper around a regular function.
          */
-        fun wrap(name: String, signature: PyCallableSignature,
-                 fn: (Map<String, PyObject>) -> PyObject): PyBuiltinFunction {
+        fun wrap(
+            name: String, signature: PyCallableSignature,
+            fn: (Map<String, PyObject>) -> PyObject
+        ): PyBuiltinFunction {
             return object : PyBuiltinFunction(name) {
                 override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
                     return fn(kwargs)
@@ -54,10 +56,9 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction(PyBuiltinFunctio
         }
     }
 
-    override fun pyStr(): PyString =
-        PyString("<built-in function $name>")
+    override fun getPyStr(): PyString = PyString("<built-in function $name>")
 
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyRepr(): PyString = getPyStr()
 
     /**
      * Called when the function is called from within a stack frame.

--- a/src/main/kotlin/interpreter/functions/PyUserFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyUserFunction.kt
@@ -89,9 +89,9 @@ class PyUserFunction(codeObject: KyCodeObject) : PyFunction(PyUserFunctionType) 
     override fun getFrame(): StackFrame =
         UserCodeStackFrame(this)
 
-    override fun pyStr(): PyString =
-        PyString("<user function ${code.codename}>")
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyStr(): PyString = PyString("<user function ${code.codename}>")
+
+    override fun getPyRepr(): PyString = getPyStr()
 
     /**
      * Generates a [PyCallableSignature] for this function.

--- a/src/main/kotlin/interpreter/kyobject/KyCodeObject.kt
+++ b/src/main/kotlin/interpreter/kyobject/KyCodeObject.kt
@@ -20,7 +20,6 @@ package green.sailor.kython.interpreter.kyobject
 
 import green.sailor.kython.interpreter.instruction.Instruction
 import green.sailor.kython.interpreter.instruction.InstructionOpcode
-import green.sailor.kython.interpreter.pyobject.PyObject
 import green.sailor.kython.interpreter.stack.UserCodeStackFrame
 import green.sailor.kython.kyc.KycCodeObject
 import green.sailor.kython.util.Lnotab
@@ -90,7 +89,7 @@ class KyCodeObject(original: KycCodeObject) {
 
     // TODO: Unwrap these into real objects.
     /** The constants for this function. */
-    val consts = original.consts.wrapped.map { PyObject.wrapKyc(it) }
+    val consts = original.consts.wrap()
 
     /** The names for this function. */
     val names = original.names.wrapped.map { it.wrapped as String }

--- a/src/main/kotlin/interpreter/pyobject/PyBool.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBool.kt
@@ -36,7 +36,7 @@ class PyBool private constructor(val wrapped: Boolean) : PyObject(PyBoolType) {
     val cachedFalseString =
         PyString("False")
 
-    override fun pyStr(): PyString = if (this.wrapped) cachedTrueString else cachedFalseString
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyStr(): PyString = if (this.wrapped) cachedTrueString else cachedFalseString
+    override fun getPyRepr(): PyString = getPyStr()
 
 }

--- a/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
@@ -24,10 +24,10 @@ import green.sailor.kython.interpreter.kyobject.KyCodeObject
  * Represents a code object. Wraps a KyCodeObject, but exposes it to Python.
  */
 class PyCodeObject(val wrappedCodeObject: KyCodeObject) : PyObject() {
-    override fun pyStr(): PyString {
+    override fun getPyStr(): PyString {
         return PyString("<code object ${wrappedCodeObject.codename}>")
     }
 
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyRepr(): PyString = getPyStr()
 
 }

--- a/src/main/kotlin/interpreter/pyobject/PyDict.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyDict.kt
@@ -51,14 +51,14 @@ class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject(Py
         }
     }
 
-    override fun pyStr(): PyString {
+    override fun getPyStr(): PyString {
         val joined = this.items.entries.joinToString {
-            it.key.pyRepr().wrappedString + ": " + it.value.pyRepr().wrappedString
+            it.key.getPyRepr().wrappedString + ": " + it.value.getPyRepr().wrappedString
         }
         return PyString("{$joined}")
     }
 
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyRepr(): PyString = getPyStr()
 
     /**
      * Gets an item from the internal dict.

--- a/src/main/kotlin/interpreter/pyobject/PyException.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyException.kt
@@ -65,7 +65,7 @@ abstract class PyException(val args: PyTuple) : PyObject() {
             return object : PyExceptionType(name) {
                 override fun newInstance(kwargs: Map<String, PyObject>): PyObject {
                     val args = kwargs["args"] as PyTuple
-                    val strings = args.subobjects.map { it.pyStr() }
+                    val strings = args.subobjects.map { it.getPyStr() }
 
                     return this.interpreterGetExceptionInstance(strings)
                 }
@@ -94,12 +94,12 @@ abstract class PyException(val args: PyTuple) : PyObject() {
         this.exceptionFrames = frames
     }
 
-    override fun pyStr(): PyString {
+    override fun getPyStr(): PyString {
         require(this.type is PyExceptionType) { "Type of exception was not PyExceptionType!" }
         TODO()
     }
 
-    override fun pyRepr(): PyString {
+    override fun getPyRepr(): PyString {
         TODO("not implemented")
     }
 }

--- a/src/main/kotlin/interpreter/pyobject/PyInt.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyInt.kt
@@ -25,9 +25,9 @@ import green.sailor.kython.interpreter.pyobject.types.PyIntType
  */
 class PyInt(val wrappedInt: Long) : PyObject(PyIntType) {
 
-    override fun pyStr(): PyString =
-        PyString(this.wrappedInt.toString())
-    override fun pyRepr(): PyString = this.pyStr()
+    override fun getPyStr(): PyString = PyString(this.wrappedInt.toString())
+
+    override fun getPyRepr(): PyString = this.getPyStr()
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/src/main/kotlin/interpreter/pyobject/PyMethod.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyMethod.kt
@@ -44,7 +44,7 @@ class PyMethod(
 
     override val signature: PyCallableSignature = this.function.signature
 
-    override fun pyStr(): PyString {
+    override fun getPyStr(): PyString {
         val builder = StringBuilder()
 
         builder.append("<method '")
@@ -56,6 +56,6 @@ class PyMethod(
         return PyString(builder.toString())
     }
 
-    override fun pyRepr(): PyString = this.pyStr()
+    override fun getPyRepr(): PyString = this.getPyStr()
 
 }

--- a/src/main/kotlin/interpreter/pyobject/PyNone.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyNone.kt
@@ -28,8 +28,7 @@ object PyNone : PyObject(PyNoneType) {
     private val noneString =
         PyString("None")
 
-    override fun pyStr(): PyString =
-        noneString
-    override fun pyRepr(): PyString =
-        noneString
+    override fun getPyStr(): PyString = noneString
+
+    override fun getPyRepr(): PyString = noneString
 }

--- a/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
@@ -32,6 +32,7 @@ class PyRootObjectInstance : PyObject(PyRootObjectType) {
         _cached = if (ooEnabled) PyString("[object Object]") else PyString("<object object>")
     }
 
-    override fun pyRepr(): PyString = pyStr()
-    override fun pyStr(): PyString = _cached
+    override fun getPyRepr(): PyString = getPyStr()
+
+    override fun getPyStr(): PyString = _cached
 }

--- a/src/main/kotlin/interpreter/pyobject/PySet.kt
+++ b/src/main/kotlin/interpreter/pyobject/PySet.kt
@@ -26,9 +26,9 @@ import green.sailor.kython.interpreter.pyobject.types.PySetType
  */
 class PySet(val wrappedSet: LinkedHashSet<PyObject>) : PyObject(PySetType) {
 
-    override fun pyStr(): PyString =
-        PyString(
-            this.wrappedSet.joinToString(", ") { it.pyRepr().wrappedString }
-        )
-    override fun pyRepr(): PyString = pyStr()
+    override fun getPyStr(): PyString = PyString(
+        this.wrappedSet.joinToString(", ") { it.getPyRepr().wrappedString }
+    )
+
+    override fun getPyRepr(): PyString = getPyStr()
 }

--- a/src/main/kotlin/interpreter/pyobject/PyString.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyString.kt
@@ -31,9 +31,8 @@ class PyString(val wrappedString: String) : PyObject(PyStringType) {
             PyString("<unprintable>")
     }
 
-    override fun pyStr(): PyString = this
-    override fun pyRepr(): PyString =
-        PyString("'${this.wrappedString}'")
+    override fun getPyStr(): PyString = this
+    override fun getPyRepr(): PyString = PyString("'${this.wrappedString}'")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {

--- a/src/main/kotlin/interpreter/pyobject/PyTuple.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyTuple.kt
@@ -31,13 +31,13 @@ class PyTuple(val subobjects: List<PyObject>) : PyObject(PyTupleType) {
         val EMPTY = PyTuple(listOf())
     }
 
-    override fun pyStr(): PyString {
+    override fun getPyStr(): PyString {
         return PyString("(" + this.subobjects.joinToString {
-            it.pyRepr().wrappedString
+            it.getPyRepr().wrappedString
         } + ")")
     }
 
-    override fun pyRepr(): PyString = this.pyStr()
+    override fun getPyRepr(): PyString = this.getPyStr()
 
 
 }

--- a/src/main/kotlin/interpreter/pyobject/PyType.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyType.kt
@@ -61,6 +61,7 @@ abstract class PyType(val name: String) : PyObject(), PyCallable {
     }
 
     // default impls
-    override fun pyStr(): PyString = this._pyString
-    override fun pyRepr(): PyString = this._pyString
+    override fun getPyStr(): PyString = this._pyString
+
+    override fun getPyRepr(): PyString = this._pyString
 }

--- a/src/main/kotlin/interpreter/pyobject/types/PyStringType.kt
+++ b/src/main/kotlin/interpreter/pyobject/types/PyStringType.kt
@@ -31,7 +31,7 @@ import green.sailor.kython.interpreter.throwKy
 object PyStringType : PyType("str") {
     override fun newInstance(args: Map<String, PyObject>): PyObject {
         val arg = args["x"]!!
-        return arg.pyStr()
+        return arg.getPyStr()
     }
 
     override val signature: PyCallableSignature by lazy {


### PR DESCRIPTION
This PR adds a `Wrappable` interface, which aids with general wrapping of objects of type `T: BaseKycType` into `U: PyObject`.
It also turns no-param getter functions of `PyObject` into member properties for idiomatic access. 

PR is a draft due to pending merge of #3.