### PR TITLE
Implement more opcodes

### DIFF
--- a/src/main/kotlin/interpreter/Builtins.kt
+++ b/src/main/kotlin/interpreter/Builtins.kt
@@ -23,7 +23,6 @@ import green.sailor.kython.interpreter.functions.PrintBuiltinFunction
 import green.sailor.kython.interpreter.functions.PyBuiltinFunction
 import green.sailor.kython.interpreter.iface.ArgType
 import green.sailor.kython.interpreter.iface.PyCallableSignature
-import green.sailor.kython.interpreter.pyobject.PyBytes
 import green.sailor.kython.interpreter.pyobject.PyNone
 import green.sailor.kython.interpreter.pyobject.types.*
 

--- a/src/main/kotlin/interpreter/Builtins.kt
+++ b/src/main/kotlin/interpreter/Builtins.kt
@@ -23,6 +23,7 @@ import green.sailor.kython.interpreter.functions.PrintBuiltinFunction
 import green.sailor.kython.interpreter.functions.PyBuiltinFunction
 import green.sailor.kython.interpreter.iface.ArgType
 import green.sailor.kython.interpreter.iface.PyCallableSignature
+import green.sailor.kython.interpreter.pyobject.PyBytes
 import green.sailor.kython.interpreter.pyobject.PyNone
 import green.sailor.kython.interpreter.pyobject.types.*
 

--- a/src/main/kotlin/interpreter/Builtins.kt
+++ b/src/main/kotlin/interpreter/Builtins.kt
@@ -17,10 +17,7 @@
  */
 package green.sailor.kython.interpreter
 
-import green.sailor.kython.interpreter.functions.DirBuiltinFunction
-import green.sailor.kython.interpreter.functions.LocalsBuiltinFunction
-import green.sailor.kython.interpreter.functions.PrintBuiltinFunction
-import green.sailor.kython.interpreter.functions.PyBuiltinFunction
+import green.sailor.kython.interpreter.functions.*
 import green.sailor.kython.interpreter.iface.ArgType
 import green.sailor.kython.interpreter.iface.PyCallableSignature
 import green.sailor.kython.interpreter.pyobject.PyNone
@@ -34,6 +31,7 @@ object Builtins {
     val PRINT = PrintBuiltinFunction()
     val LOCALS = LocalsBuiltinFunction()
     val DIR = DirBuiltinFunction()
+    val ITER = IterBuiltinFunction()
     val KY_PRINT = PyBuiltinFunction.wrap(
         "ky_print", PyCallableSignature("any" to ArgType.POSITIONAL)
     ) {
@@ -58,6 +56,7 @@ object Builtins {
         "print" to PRINT,
         "locals" to LOCALS,
         "dir" to DIR,
+        "iter" to ITER,
         "_ky_print" to KY_PRINT,
 
         // class types

--- a/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
@@ -1,0 +1,42 @@
+/*
+ * This file is part of kython.
+ *
+ * kython is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * kython is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with kython.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package green.sailor.kython.interpreter.functions
+
+import green.sailor.kython.interpreter.Exceptions
+import green.sailor.kython.interpreter.iface.ArgType
+import green.sailor.kython.interpreter.iface.PyCallable
+import green.sailor.kython.interpreter.iface.PyCallableSignature
+import green.sailor.kython.interpreter.pyobject.PyObject
+import green.sailor.kython.interpreter.throwKy
+
+/**
+ * Represents the iter(x) built-in function.
+ */
+class IterBuiltinFunction : PyBuiltinFunction("iter") {
+    override val signature: PyCallableSignature = PyCallableSignature("obb" to ArgType.POSITIONAL)
+
+    override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
+        val obb = kwargs["obb"] ?: error("Built-in signature mismatch!")
+        val iter = obb.pyGetAttribute("__iter__")
+        if (iter !is PyCallable) {
+            Exceptions.TYPE_ERROR("__iter__ is not callable").throwKy()
+        }
+        return iter.runCallable(listOf(obb))
+    }
+}

--- a/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
@@ -15,7 +15,6 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 package green.sailor.kython.interpreter.functions
 
 import green.sailor.kython.interpreter.Exceptions
@@ -29,14 +28,15 @@ import green.sailor.kython.interpreter.throwKy
  * Represents the iter(x) built-in function.
  */
 class IterBuiltinFunction : PyBuiltinFunction("iter") {
-    override val signature: PyCallableSignature = PyCallableSignature("obb" to ArgType.POSITIONAL)
+    override val signature: PyCallableSignature = PyCallableSignature("obb" to ArgType.POSITIONAL, "sentinel" to ArgType.KEYWORD)
 
     override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
         val obb = kwargs["obb"] ?: error("Built-in signature mismatch!")
+        val sentinel = kwargs["sentinel"]
         val iter = obb.pyGetAttribute("__iter__")
         if (iter !is PyCallable) {
             Exceptions.TYPE_ERROR("__iter__ is not callable").throwKy()
         }
-        return iter.runCallable(listOf(obb))
+        return iter.runCallable(if(sentinel == null) listOf(obb) else listOf(obb, sentinel))
     }
 }

--- a/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
@@ -28,7 +28,10 @@ import green.sailor.kython.interpreter.throwKy
  * Represents the iter(x) built-in function.
  */
 class IterBuiltinFunction : PyBuiltinFunction("iter") {
-    override val signature: PyCallableSignature = PyCallableSignature("obb" to ArgType.POSITIONAL, "sentinel" to ArgType.KEYWORD)
+    override val signature: PyCallableSignature = PyCallableSignature(
+        "obb" to ArgType.POSITIONAL,
+        "sentinel" to ArgType.KEYWORD
+    )
 
     override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
         val obb = kwargs["obb"] ?: error("Built-in signature mismatch!")
@@ -37,6 +40,6 @@ class IterBuiltinFunction : PyBuiltinFunction("iter") {
         if (iter !is PyCallable) {
             Exceptions.TYPE_ERROR("__iter__ is not callable").throwKy()
         }
-        return iter.runCallable(if(sentinel == null) listOf(obb) else listOf(obb, sentinel))
+        return iter.runCallable(if (sentinel == null) listOf(obb) else listOf(obb, sentinel))
     }
 }

--- a/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/IterBuiltinFunction.kt
@@ -40,6 +40,6 @@ class IterBuiltinFunction : PyBuiltinFunction("iter") {
         if (iter !is PyCallable) {
             Exceptions.TYPE_ERROR("__iter__ is not callable").throwKy()
         }
-        return iter.runCallable(if (sentinel == null) listOf(obb) else listOf(obb, sentinel))
+        return iter.runCallable(if (sentinel == null) listOf() else listOf(sentinel))
     }
 }

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -161,13 +161,15 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
                     InstructionOpcode.BUILD_SET -> buildSimple(BuildType.SET, param)
 
                     // binary ops
-<<<<<<< HEAD
                     InstructionOpcode.BINARY_ADD -> binaryOp(BinaryOp.ADD, param)
                     InstructionOpcode.BINARY_POWER -> binaryOp(BinaryOp.POWER, param)
                     InstructionOpcode.BINARY_MULTIPLY -> binaryOp(BinaryOp.MULTIPLY, param)
-                    InstructionOpcode.BINARY_MATRIX_MULTIPLY -> binaryOp(BinaryOp.MATRIX_MULTIPLY, param)
-                    InstructionOpcode.BINARY_FLOOR_DIVIDE -> binaryOp(BinaryOp.FLOOR_DIVIDE, param)
-                    InstructionOpcode.BINARY_TRUE_DIVIDE -> binaryOp(BinaryOp.TRUE_DIVIDE, param)
+                    InstructionOpcode.BINARY_MATRIX_MULTIPLY ->
+                        binaryOp(BinaryOp.MATRIX_MULTIPLY, param)
+                    InstructionOpcode.BINARY_FLOOR_DIVIDE ->
+                        binaryOp(BinaryOp.FLOOR_DIVIDE, param)
+                    InstructionOpcode.BINARY_TRUE_DIVIDE ->
+                        binaryOp(BinaryOp.TRUE_DIVIDE, param)
                     InstructionOpcode.BINARY_MODULO -> binaryOp(BinaryOp.MODULO, param)
                     InstructionOpcode.BINARY_SUBTRACT -> binaryOp(BinaryOp.SUBTRACT, param)
                     InstructionOpcode.BINARY_SUBSCR -> binaryOp(BinaryOp.SUBSCR, param)
@@ -181,9 +183,12 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
                     InstructionOpcode.INPLACE_ADD -> inplaceOp(BinaryOp.ADD, param)
                     InstructionOpcode.INPLACE_POWER -> inplaceOp(BinaryOp.POWER, param)
                     InstructionOpcode.INPLACE_MULTIPLY -> inplaceOp(BinaryOp.MULTIPLY, param)
-                    InstructionOpcode.INPLACE_MATRIX_MULTIPLY -> inplaceOp(BinaryOp.MATRIX_MULTIPLY, param)
-                    InstructionOpcode.INPLACE_FLOOR_DIVIDE -> inplaceOp(BinaryOp.FLOOR_DIVIDE, param)
-                    InstructionOpcode.INPLACE_TRUE_DIVIDE -> inplaceOp(BinaryOp.TRUE_DIVIDE, param)
+                    InstructionOpcode.INPLACE_MATRIX_MULTIPLY ->
+                        inplaceOp(BinaryOp.MATRIX_MULTIPLY, param)
+                    InstructionOpcode.INPLACE_FLOOR_DIVIDE ->
+                        inplaceOp(BinaryOp.FLOOR_DIVIDE, param)
+                    InstructionOpcode.INPLACE_TRUE_DIVIDE ->
+                        inplaceOp(BinaryOp.TRUE_DIVIDE, param)
                     InstructionOpcode.INPLACE_MODULO -> inplaceOp(BinaryOp.MODULO, param)
                     InstructionOpcode.INPLACE_SUBTRACT -> inplaceOp(BinaryOp.SUBTRACT, param)
                     InstructionOpcode.INPLACE_LSHIFT -> inplaceOp(BinaryOp.LSHIFT, param)
@@ -193,45 +198,6 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
                     InstructionOpcode.INPLACE_OR -> inplaceOp(BinaryOp.OR, param)
                     InstructionOpcode.STORE_SUBSCR -> inplaceOp(BinaryOp.STORE_SUBSCR, param)
                     InstructionOpcode.DELETE_SUBSCR -> inplaceOp(BinaryOp.DELETE_SUBSCR, param)
-=======
-                    InstructionOpcode.BINARY_ADD -> this.binaryOp(BinaryOp.ADD, param)
-                    InstructionOpcode.BINARY_POWER -> this.binaryOp(BinaryOp.POWER, param)
-                    InstructionOpcode.BINARY_MULTIPLY -> this.binaryOp(BinaryOp.MULTIPLY, param)
-                    InstructionOpcode.BINARY_MATRIX_MULTIPLY ->
-                        this.binaryOp(BinaryOp.MATRIX_MULTIPLY, param)
-                    InstructionOpcode.BINARY_FLOOR_DIVIDE ->
-                        this.binaryOp(BinaryOp.FLOOR_DIVIDE, param)
-                    InstructionOpcode.BINARY_TRUE_DIVIDE ->
-                        this.binaryOp(BinaryOp.TRUE_DIVIDE, param)
-                    InstructionOpcode.BINARY_MODULO -> this.binaryOp(BinaryOp.MODULO, param)
-                    InstructionOpcode.BINARY_SUBTRACT -> this.binaryOp(BinaryOp.SUBTRACT, param)
-                    InstructionOpcode.BINARY_SUBSCR -> this.binaryOp(BinaryOp.SUBSCR, param)
-                    InstructionOpcode.BINARY_LSHIFT -> this.binaryOp(BinaryOp.LSHIFT, param)
-                    InstructionOpcode.BINARY_RSHIFT -> this.binaryOp(BinaryOp.RSHIFT, param)
-                    InstructionOpcode.BINARY_AND -> this.binaryOp(BinaryOp.AND, param)
-                    InstructionOpcode.BINARY_XOR -> this.binaryOp(BinaryOp.XOR, param)
-                    InstructionOpcode.BINARY_OR -> this.binaryOp(BinaryOp.OR, param)
-
-                    // inplace binary ops
-                    InstructionOpcode.INPLACE_ADD -> this.inplaceOp(BinaryOp.ADD, param)
-                    InstructionOpcode.INPLACE_POWER -> this.inplaceOp(BinaryOp.POWER, param)
-                    InstructionOpcode.INPLACE_MULTIPLY -> this.inplaceOp(BinaryOp.MULTIPLY, param)
-                    InstructionOpcode.INPLACE_MATRIX_MULTIPLY ->
-                        this.inplaceOp(BinaryOp.MATRIX_MULTIPLY, param)
-                    InstructionOpcode.INPLACE_FLOOR_DIVIDE ->
-                        this.inplaceOp(BinaryOp.FLOOR_DIVIDE, param)
-                    InstructionOpcode.INPLACE_TRUE_DIVIDE ->
-                        this.inplaceOp(BinaryOp.TRUE_DIVIDE, param)
-                    InstructionOpcode.INPLACE_MODULO -> this.inplaceOp(BinaryOp.MODULO, param)
-                    InstructionOpcode.INPLACE_SUBTRACT -> this.inplaceOp(BinaryOp.SUBTRACT, param)
-                    InstructionOpcode.INPLACE_LSHIFT -> this.inplaceOp(BinaryOp.LSHIFT, param)
-                    InstructionOpcode.INPLACE_RSHIFT -> this.inplaceOp(BinaryOp.RSHIFT, param)
-                    InstructionOpcode.INPLACE_AND -> this.inplaceOp(BinaryOp.AND, param)
-                    InstructionOpcode.INPLACE_XOR -> this.inplaceOp(BinaryOp.XOR, param)
-                    InstructionOpcode.INPLACE_OR -> this.inplaceOp(BinaryOp.OR, param)
-                    InstructionOpcode.STORE_SUBSCR -> this.inplaceOp(BinaryOp.STORE_SUBSCR, param)
-                    InstructionOpcode.DELETE_SUBSCR -> this.inplaceOp(BinaryOp.DELETE_SUBSCR, param)
->>>>>>> Lint code
 
                     // fundamentally the same thing.
                     InstructionOpcode.CALL_METHOD -> callFunction(param)
@@ -357,33 +323,17 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
      * MAKE_FUNCTION.
      */
     fun makeFunction(arg: Byte) {
-<<<<<<< HEAD
         val flags = arg.toInt()  // To use bitwise and
         val qualifiedName = stack.pop()
-=======
-        val flags = arg.toInt() // To use bitwise and
-
-        val qualifiedName = this.stack.pop()
->>>>>>> Lint code
         require(qualifiedName is PyString) { "Function qualified name was not string!" }
 
         val code = stack.pop()
         require(code is PyCodeObject) { "Function code was not a code object!" }
-
-<<<<<<< HEAD
-
         if (flags and 8 == 8){
             val freevarCellsTuple = stack.pop()
         }
         if (flags and 4 == 4){
             val annotationDict = stack.pop()
-=======
-        if (flags and 8 == 8) {
-            val freevarCellsTuple = this.stack.pop()
-        }
-        if (flags and 4 == 4) {
-            val annotationDict = this.stack.pop()
->>>>>>> Lint code
         }
         if (flags and 2 == 2) {
             val kwOnlyParamDefaultDict = stack.pop()

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -323,7 +323,8 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
      * MAKE_FUNCTION.
      */
     fun makeFunction(arg: Byte) {
-        val flags = arg.toInt()  // To use bitwise and
+        // toInt to use bitwise `and`
+        val flags = arg.toInt()
         val qualifiedName = stack.pop()
         require(qualifiedName is PyString) { "Function qualified name was not string!" }
 

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -329,10 +329,10 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
 
         val code = stack.pop()
         require(code is PyCodeObject) { "Function code was not a code object!" }
-        if (flags and 8 == 8){
+        if (flags and 8 == 8) {
             val freevarCellsTuple = stack.pop()
         }
-        if (flags and 4 == 4){
+        if (flags and 4 == 4) {
             val annotationDict = stack.pop()
         }
         if (flags and 2 == 2) {
@@ -494,7 +494,7 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
             BinaryOp.OR -> "__or__"
             else -> error("This should never happen!")
         }
-        magicMethod(o1, magic, o2, "__r"+magic.substring(2))
+        magicMethod(o1, magic, o2, "__r" + magic.substring(2))
         bytecodePointer += 1
     }
 

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -79,24 +79,24 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
         }
 
         object FunctionFlags {
-            val POSITIONAL_DEFAULT = 1
-            val KEYWORD_DEFAULT = 2
-            val ANNOTATIONS = 4
-            val FREEVARS = 8
+            const val POSITIONAL_DEFAULT = 1
+            const val KEYWORD_DEFAULT = 2
+            const val ANNOTATIONS = 4
+            const val FREEVARS = 8
         }
 
         object CompareOp {
-            val LESS = 0
-            val LESS_EQUAL = 1
-            val GREATER = 2
-            val GREATER_EQUAL = 3
-            val EQUAL = 4
-            val NOT_EQUAL = 5
-            val CONTAINS = 6
-            val NOT_CONTAINS = 7
-            val IS = 8
-            val IS_NOT = 9
-            val EXCEPTION_MATCH = 10
+            const val LESS = 0
+            const val LESS_EQUAL = 1
+            const val GREATER = 2
+            const val GREATER_EQUAL = 3
+            const val EQUAL = 4
+            const val NOT_EQUAL = 5
+            const val CONTAINS = 6
+            const val NOT_CONTAINS = 7
+            const val IS = 8
+            const val IS_NOT = 9
+            const val EXCEPTION_MATCH = 10
         }
     }
 

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -24,7 +24,6 @@ import green.sailor.kython.interpreter.functions.PyUserFunction
 import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.instruction.InstructionOpcode
 import green.sailor.kython.interpreter.pyobject.*
-import green.sailor.kython.interpreter.pyobject.types.PyBoolType
 import green.sailor.kython.interpreter.throwKy
 import java.util.*
 
@@ -101,7 +100,7 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
     /**
      * Utility function for calling magic methods
      */
-    fun magicMethod(obj: PyObject, magicName: String, param: PyObject?){
+    fun magicMethod(obj: PyObject, magicName: String, param: PyObject?) {
         val fn = obj.pyGetAttribute(magicName)
         if (fn !is PyCallable) {
             Exceptions.TYPE_ERROR("'${obj.type.name}'.$magicName is not callable.").throwKy()
@@ -162,6 +161,7 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
                     InstructionOpcode.BUILD_SET -> buildSimple(BuildType.SET, param)
 
                     // binary ops
+<<<<<<< HEAD
                     InstructionOpcode.BINARY_ADD -> binaryOp(BinaryOp.ADD, param)
                     InstructionOpcode.BINARY_POWER -> binaryOp(BinaryOp.POWER, param)
                     InstructionOpcode.BINARY_MULTIPLY -> binaryOp(BinaryOp.MULTIPLY, param)
@@ -193,6 +193,45 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
                     InstructionOpcode.INPLACE_OR -> inplaceOp(BinaryOp.OR, param)
                     InstructionOpcode.STORE_SUBSCR -> inplaceOp(BinaryOp.STORE_SUBSCR, param)
                     InstructionOpcode.DELETE_SUBSCR -> inplaceOp(BinaryOp.DELETE_SUBSCR, param)
+=======
+                    InstructionOpcode.BINARY_ADD -> this.binaryOp(BinaryOp.ADD, param)
+                    InstructionOpcode.BINARY_POWER -> this.binaryOp(BinaryOp.POWER, param)
+                    InstructionOpcode.BINARY_MULTIPLY -> this.binaryOp(BinaryOp.MULTIPLY, param)
+                    InstructionOpcode.BINARY_MATRIX_MULTIPLY ->
+                        this.binaryOp(BinaryOp.MATRIX_MULTIPLY, param)
+                    InstructionOpcode.BINARY_FLOOR_DIVIDE ->
+                        this.binaryOp(BinaryOp.FLOOR_DIVIDE, param)
+                    InstructionOpcode.BINARY_TRUE_DIVIDE ->
+                        this.binaryOp(BinaryOp.TRUE_DIVIDE, param)
+                    InstructionOpcode.BINARY_MODULO -> this.binaryOp(BinaryOp.MODULO, param)
+                    InstructionOpcode.BINARY_SUBTRACT -> this.binaryOp(BinaryOp.SUBTRACT, param)
+                    InstructionOpcode.BINARY_SUBSCR -> this.binaryOp(BinaryOp.SUBSCR, param)
+                    InstructionOpcode.BINARY_LSHIFT -> this.binaryOp(BinaryOp.LSHIFT, param)
+                    InstructionOpcode.BINARY_RSHIFT -> this.binaryOp(BinaryOp.RSHIFT, param)
+                    InstructionOpcode.BINARY_AND -> this.binaryOp(BinaryOp.AND, param)
+                    InstructionOpcode.BINARY_XOR -> this.binaryOp(BinaryOp.XOR, param)
+                    InstructionOpcode.BINARY_OR -> this.binaryOp(BinaryOp.OR, param)
+
+                    // inplace binary ops
+                    InstructionOpcode.INPLACE_ADD -> this.inplaceOp(BinaryOp.ADD, param)
+                    InstructionOpcode.INPLACE_POWER -> this.inplaceOp(BinaryOp.POWER, param)
+                    InstructionOpcode.INPLACE_MULTIPLY -> this.inplaceOp(BinaryOp.MULTIPLY, param)
+                    InstructionOpcode.INPLACE_MATRIX_MULTIPLY ->
+                        this.inplaceOp(BinaryOp.MATRIX_MULTIPLY, param)
+                    InstructionOpcode.INPLACE_FLOOR_DIVIDE ->
+                        this.inplaceOp(BinaryOp.FLOOR_DIVIDE, param)
+                    InstructionOpcode.INPLACE_TRUE_DIVIDE ->
+                        this.inplaceOp(BinaryOp.TRUE_DIVIDE, param)
+                    InstructionOpcode.INPLACE_MODULO -> this.inplaceOp(BinaryOp.MODULO, param)
+                    InstructionOpcode.INPLACE_SUBTRACT -> this.inplaceOp(BinaryOp.SUBTRACT, param)
+                    InstructionOpcode.INPLACE_LSHIFT -> this.inplaceOp(BinaryOp.LSHIFT, param)
+                    InstructionOpcode.INPLACE_RSHIFT -> this.inplaceOp(BinaryOp.RSHIFT, param)
+                    InstructionOpcode.INPLACE_AND -> this.inplaceOp(BinaryOp.AND, param)
+                    InstructionOpcode.INPLACE_XOR -> this.inplaceOp(BinaryOp.XOR, param)
+                    InstructionOpcode.INPLACE_OR -> this.inplaceOp(BinaryOp.OR, param)
+                    InstructionOpcode.STORE_SUBSCR -> this.inplaceOp(BinaryOp.STORE_SUBSCR, param)
+                    InstructionOpcode.DELETE_SUBSCR -> this.inplaceOp(BinaryOp.DELETE_SUBSCR, param)
+>>>>>>> Lint code
 
                     // fundamentally the same thing.
                     InstructionOpcode.CALL_METHOD -> callFunction(param)
@@ -318,19 +357,33 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
      * MAKE_FUNCTION.
      */
     fun makeFunction(arg: Byte) {
+<<<<<<< HEAD
         val flags = arg.toInt()  // To use bitwise and
         val qualifiedName = stack.pop()
+=======
+        val flags = arg.toInt() // To use bitwise and
+
+        val qualifiedName = this.stack.pop()
+>>>>>>> Lint code
         require(qualifiedName is PyString) { "Function qualified name was not string!" }
 
         val code = stack.pop()
         require(code is PyCodeObject) { "Function code was not a code object!" }
 
+<<<<<<< HEAD
 
         if (flags and 8 == 8){
             val freevarCellsTuple = stack.pop()
         }
         if (flags and 4 == 4){
             val annotationDict = stack.pop()
+=======
+        if (flags and 8 == 8) {
+            val freevarCellsTuple = this.stack.pop()
+        }
+        if (flags and 4 == 4) {
+            val annotationDict = this.stack.pop()
+>>>>>>> Lint code
         }
         if (flags and 2 == 2) {
             val kwOnlyParamDefaultDict = stack.pop()
@@ -373,7 +426,7 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
     /**
      * IMPORT_STAR
      */
-    fun importStar(arg: Byte){
+    fun importStar(arg: Byte) {
         val module = stack.pop()
 
         // Assuming internalDict is __dir__
@@ -526,20 +579,20 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
     fun compareOp(arg: Byte) {
         val top = stack.pop()
         val second = stack.pop()
-        when (arg.toInt()){
+        when (arg.toInt()) {
             0 -> magicMethod(top, "__lt__", second, "__ge__")
-            1 -> magicMethod(top,"__le__", second, "__gt__")
-            2 -> magicMethod(top,"__gt__", second, "__le__")
-            3 -> magicMethod(top,"__ge__", second, "__lt__")
-            4 -> magicMethod(top,"__eq__", second, "__eq__")
-            5 -> magicMethod(top,"__ne__", second, "__ne__")
-            6 -> magicMethod(top,"__contains__", second)
+            1 -> magicMethod(top, "__le__", second, "__gt__")
+            2 -> magicMethod(top, "__gt__", second, "__le__")
+            3 -> magicMethod(top, "__ge__", second, "__lt__")
+            4 -> magicMethod(top, "__eq__", second, "__eq__")
+            5 -> magicMethod(top, "__ne__", second, "__ne__")
+            6 -> magicMethod(top, "__contains__", second)
             7 -> {
-                magicMethod(top,"__contains__", second)
+                magicMethod(top, "__contains__", second)
                 stack.push(if (stack.pop() == PyBool.TRUE) PyBool.FALSE else PyBool.TRUE)
             }
-            8 -> stack.push(if(top.hashCode() == second.hashCode()) PyBool.TRUE else PyBool.FALSE)
-            9 -> stack.push(if(top.hashCode() != second.hashCode()) PyBool.TRUE else PyBool.FALSE)
+            8 -> stack.push(if (top.hashCode() == second.hashCode()) PyBool.TRUE else PyBool.FALSE)
+            9 -> stack.push(if (top.hashCode() != second.hashCode()) PyBool.TRUE else PyBool.FALSE)
             10 -> TODO("exception match COMPARE_OP")
         }
     }
@@ -572,7 +625,7 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
     fun unaryNot(param: Byte) {
         val top = stack.pop()
         magicMethod(top, "__bool__")
-        val truthy = stack.pop()  // magicMethod pushes to stack
+        val truthy = stack.pop() // magicMethod pushes to stack
         stack.push(if (truthy == PyBool.TRUE) PyBool.FALSE else PyBool.TRUE)
         bytecodePointer += 1
     }


### PR DESCRIPTION
- Implements all `BINARY_*`, `INPLACE_*`, `UNARY_*`, and `COMPARE_OP` (except for 'exception match' which requires isinstance to be implemented)
- Implements the `iter()` builtin
- Adds a `magicMethod` utility function to easily call magic methods with param if needed
- Implements `IMPORT_*` (lacking a proper implementation of IMPORT_NAME due to there not being a reliable way to get all members of an object)