### PR TITLE
Make the type field less fragile.

### DIFF
--- a/src/main/kotlin/interpreter/Exceptions.kt
+++ b/src/main/kotlin/interpreter/Exceptions.kt
@@ -18,6 +18,7 @@
 package green.sailor.kython.interpreter
 
 import green.sailor.kython.interpreter.pyobject.PyException
+import green.sailor.kython.interpreter.pyobject.PyObject
 
 /**
  * A nice list of exceptions.
@@ -51,4 +52,8 @@ object Exceptions {
         "RuntimeError" to RUNTIME_ERROR,
         "NotImplementedError" to NOT_IMPLEMENTED_ERROR
     )
+
+    // helpers for common errors from builtins
+    fun invalidClassSet(parent: PyObject): Nothing =
+        TYPE_ERROR("Cannot set __class__ on object of type ${parent.type.name}").throwKy()
 }

--- a/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
@@ -69,5 +69,5 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction() {
 
     override var type: PyType
         get() = PyBuiltinFunctionType
-        set(value) = error("Cannot set the type of this object")
+        set(_) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
@@ -69,5 +69,5 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction() {
 
     override var type: PyType
         get() = PyBuiltinFunctionType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
@@ -29,7 +29,7 @@ import green.sailor.kython.interpreter.throwKy
 /**
  * Represents a built-in function, such as print().
  */
-abstract class PyBuiltinFunction(val name: String) : PyFunction(PyBuiltinFunctionType) {
+abstract class PyBuiltinFunction(val name: String) : PyFunction() {
     companion object {
 
         /**
@@ -66,4 +66,8 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction(PyBuiltinFunctio
     abstract fun callFunction(kwargs: Map<String, PyObject>): PyObject
 
     override fun createFrame(): StackFrame = BuiltinStackFrame(this)
+
+    override var type: PyType
+        get() = PyBuiltinFunctionType
+        set(value) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/functions/PyFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyFunction.kt
@@ -21,12 +21,11 @@ import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.pyobject.PyMethod
 import green.sailor.kython.interpreter.pyobject.PyNone
 import green.sailor.kython.interpreter.pyobject.PyObject
-import green.sailor.kython.interpreter.pyobject.PyType
 
 /**
  * Represents a Python function instance.
  */
-abstract class PyFunction(type: PyType) : PyObject(type), PyCallable {
+abstract class PyFunction : PyObject(), PyCallable {
     // overridden for method binding
     override fun pyDescriptorGet(parent: PyObject, klass: PyObject): PyObject {
         return if (parent is PyNone) this else PyMethod(this, parent)

--- a/src/main/kotlin/interpreter/functions/PyUserFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyUserFunction.kt
@@ -84,7 +84,7 @@ class PyUserFunction(codeObject: KyCodeObject) : PyFunction() {
 
     override var type: PyType
         get() = PyUserFunctionType
-        set(value) = error("Cannot set the type of this object")
+        set(_) = error("Cannot set the type of this object")
 
     /**
      * Generates a [PyCallableSignature] for this function.

--- a/src/main/kotlin/interpreter/functions/PyUserFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyUserFunction.kt
@@ -37,7 +37,7 @@ import green.sailor.kython.interpreter.throwKy
  *
  * @param codeObject: The marshalled code object to transform into a real code object.
  */
-class PyUserFunction(codeObject: KyCodeObject) : PyFunction(PyUserFunctionType) {
+class PyUserFunction(codeObject: KyCodeObject) : PyFunction() {
     object PyUserFunctionType : PyType("function") {
         override fun newInstance(kwargs: Map<String, PyObject>): PyObject {
             val code = kwargs["code"] ?: error("Built-in signature mismatch")
@@ -81,6 +81,10 @@ class PyUserFunction(codeObject: KyCodeObject) : PyFunction(PyUserFunctionType) 
     override fun getPyStr(): PyString = PyString("<user function ${code.codename}>")
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = PyUserFunctionType
+        set(value) = error("Cannot set the type of this object")
 
     /**
      * Generates a [PyCallableSignature] for this function.

--- a/src/main/kotlin/interpreter/functions/PyUserFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyUserFunction.kt
@@ -84,7 +84,7 @@ class PyUserFunction(codeObject: KyCodeObject) : PyFunction() {
 
     override var type: PyType
         get() = PyUserFunctionType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 
     /**
      * Generates a [PyCallableSignature] for this function.

--- a/src/main/kotlin/interpreter/functions/magic/ObjectDir.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectDir.kt
@@ -24,7 +24,7 @@ import green.sailor.kython.interpreter.pyobject.PyObject
 /**
  * Represents the default `__dir__` on objects.
  */
-class ObjectDir : PyBuiltinFunction("<object.__dir__>") {
+object ObjectDir : PyBuiltinFunction("<object.__dir__>") {
     override val signature: PyCallableSignature = PyCallableSignature.EMPTY_METHOD
 
     override fun callFunction(kwargs: Map<String, PyObject>): PyObject {

--- a/src/main/kotlin/interpreter/functions/magic/ObjectGetattribute.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectGetattribute.kt
@@ -28,7 +28,7 @@ import green.sailor.kython.interpreter.throwKy
 /**
  * Represents the default object __getattribute__.
  */
-class ObjectGetattribute : PyBuiltinFunction("<object.__getattribute__>") {
+object ObjectGetattribute : PyBuiltinFunction("<object.__getattribute__>") {
     override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
         val self = kwargs["self"]!!
         val name = kwargs["name"]!!

--- a/src/main/kotlin/interpreter/iface/PyCallableSignature.kt
+++ b/src/main/kotlin/interpreter/iface/PyCallableSignature.kt
@@ -101,7 +101,7 @@ class PyCallableSignature(vararg val args: Pair<String, ArgType>) {
                                 "not a positional argument"
                         ).throwKy()
 
-                    else -> error("Unhandled ArgType $type passed.")
+                    ArgType.KEYWORD_STAR -> {}
                 }
             }
 

--- a/src/main/kotlin/interpreter/kyobject/KyMagicMethods.kt
+++ b/src/main/kotlin/interpreter/kyobject/KyMagicMethods.kt
@@ -37,13 +37,9 @@ class KyMagicMethods(val bound: Boolean) {
     // these will *never* be null.
 
     // __getattribute__
-    val tpGetAttribute: PyCallable by lazy {
-        ObjectGetattribute()
-    }
+    val tpGetAttribute: PyCallable = ObjectGetattribute
     // __dir__
-    val tpDir: PyCallable by lazy {
-        ObjectDir()
-    }
+    val tpDir: PyCallable = ObjectDir
 
     /**
      * Turns a magic method name into a magic method.

--- a/src/main/kotlin/interpreter/pyobject/PyBool.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBool.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyBoolType
 
 /**
@@ -35,7 +36,7 @@ class PyBool private constructor(val wrapped: Boolean) : PyObject() {
 
     override var type: PyType
         get() = PyBoolType
-        set(_) = error("Cannot change the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 
     override fun getPyStr(): PyString = if (wrapped) cachedTrueString else cachedFalseString
     override fun getPyRepr(): PyString = getPyStr()

--- a/src/main/kotlin/interpreter/pyobject/PyBool.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBool.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyBoolType
 /**
  * Represents a Python boolean.
  */
-class PyBool private constructor(val wrapped: Boolean) : PyObject(PyBoolType) {
+class PyBool private constructor(val wrapped: Boolean) : PyObject() {
     companion object {
         // The TRUE instance of this.
         val TRUE = PyBool(true)
@@ -32,6 +32,10 @@ class PyBool private constructor(val wrapped: Boolean) : PyObject(PyBoolType) {
 
     private val cachedTrueString = PyString("True")
     private val cachedFalseString = PyString("False")
+
+    override var type: PyType
+        get() = PyBoolType
+        set(_) = error("Cannot change the type of this object")
 
     override fun getPyStr(): PyString = if (wrapped) cachedTrueString else cachedFalseString
     override fun getPyRepr(): PyString = getPyStr()

--- a/src/main/kotlin/interpreter/pyobject/PyBytes.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBytes.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyBytesType
 /**
  * Represents a Python bytes object. This wraps a regular JVM ByteArray.
  */
-class PyBytes(val wrapped: ByteArray) : PyObject(PyBytesType) {
+class PyBytes(val wrapped: ByteArray) : PyObject() {
     override fun getPyStr(): PyString = getPyRepr()
 
     override fun getPyRepr(): PyString {
@@ -32,6 +32,10 @@ class PyBytes(val wrapped: ByteArray) : PyObject(PyBytesType) {
         })
         return PyString("b${inner.getPyRepr().wrappedString}")
     }
+
+    override var type: PyType
+        get() = PyBytesType
+        set(value) = error("Cannot change the type of this object")
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/src/main/kotlin/interpreter/pyobject/PyBytes.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBytes.kt
@@ -35,7 +35,7 @@ class PyBytes(val wrapped: ByteArray) : PyObject() {
 
     override var type: PyType
         get() = PyBytesType
-        set(value) = error("Cannot change the type of this object")
+        set(_) = error("Cannot change the type of this object")
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/src/main/kotlin/interpreter/pyobject/PyBytes.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBytes.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyBytesType
 
 /**
@@ -35,7 +36,7 @@ class PyBytes(val wrapped: ByteArray) : PyObject() {
 
     override var type: PyType
         get() = PyBytesType
-        set(_) = error("Cannot change the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
@@ -31,5 +31,5 @@ class PyCodeObject(val wrappedCodeObject: KyCodeObject) : PyObject() {
 
     override var type: PyType
         get() = TODO("not implemented")
-        set(value) {}
+        set(_) {}
 }

--- a/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
@@ -28,4 +28,8 @@ class PyCodeObject(val wrappedCodeObject: KyCodeObject) : PyObject() {
     }
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = TODO("not implemented")
+        set(value) {}
 }

--- a/src/main/kotlin/interpreter/pyobject/PyDict.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyDict.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyDictType
 
 /**
@@ -50,7 +51,7 @@ class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject() 
 
     override var type: PyType
         get() = PyDictType
-        set(_) = error("Cannot change the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 
     /**
      * Gets an item from the internal dict.

--- a/src/main/kotlin/interpreter/pyobject/PyDict.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyDict.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyDictType
 /**
  * Represents a Python dict, a mapping between PyObject -> PyObject.
  */
-class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject(PyDictType) {
+class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject() {
     companion object {
         /** Represents the empty dict. */
         val EMPTY = PyDict(linkedMapOf())
@@ -47,6 +47,10 @@ class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject(Py
     }
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = PyDictType
+        set(_) = error("Cannot change the type of this object")
 
     /**
      * Gets an item from the internal dict.

--- a/src/main/kotlin/interpreter/pyobject/PyException.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyException.kt
@@ -18,6 +18,7 @@
 package green.sailor.kython.interpreter.pyobject
 
 import green.sailor.kython.interpreter.KythonInterpreter
+import green.sailor.kython.interpreter.pyobject.types.PyRootType
 import green.sailor.kython.interpreter.stack.StackFrame
 
 /**
@@ -49,6 +50,10 @@ abstract class PyException(val args: PyTuple) : PyObject() {
         fun typeSubclassOf(name: String): PyExceptionType {
             return makeExceptionType(name, listOf(this))
         }
+
+        override var type: PyType
+            get() = PyRootType
+            set(value) = error("Cannot set the type of this object")
     }
 
     companion object {
@@ -68,12 +73,17 @@ abstract class PyException(val args: PyTuple) : PyObject() {
                 }
 
                 override fun interpreterGetExceptionInstance(args: List<PyString>): PyException {
+                    // used to capture the outer this
+                    val innerClassType = this
                     val instance = object : PyException(PyTuple(args)) {
                         init {
                             parentTypes.addAll(bases)
                         }
+
+                        override var type: PyType
+                            get() = innerClassType
+                            set(value) {}
                     }
-                    instance.type = this
                     return instance
                 }
             }

--- a/src/main/kotlin/interpreter/pyobject/PyException.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyException.kt
@@ -53,7 +53,7 @@ abstract class PyException(val args: PyTuple) : PyObject() {
 
         override var type: PyType
             get() = PyRootType
-            set(value) = error("Cannot set the type of this object")
+            set(_) = error("Cannot set the type of this object")
     }
 
     companion object {
@@ -82,7 +82,7 @@ abstract class PyException(val args: PyTuple) : PyObject() {
 
                         override var type: PyType
                             get() = innerClassType
-                            set(value) {}
+                            set(_) {}
                     }
                     return instance
                 }

--- a/src/main/kotlin/interpreter/pyobject/PyException.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyException.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.KythonInterpreter
 import green.sailor.kython.interpreter.pyobject.types.PyRootType
 import green.sailor.kython.interpreter.stack.StackFrame
@@ -53,7 +54,7 @@ abstract class PyException(val args: PyTuple) : PyObject() {
 
         override var type: PyType
             get() = PyRootType
-            set(_) = error("Cannot set the type of this object")
+            set(_) = Exceptions.invalidClassSet(this)
     }
 
     companion object {

--- a/src/main/kotlin/interpreter/pyobject/PyFloat.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyFloat.kt
@@ -23,11 +23,15 @@ import green.sailor.kython.interpreter.pyobject.types.PyFloatType
  * Represents a Python float. This wraps a kotlin Double (CPython wraps a C double,
  * so we're consistent there).
  */
-class PyFloat(val wrapped: Double) : PyObject(PyFloatType) {
+class PyFloat(val wrapped: Double) : PyObject() {
     private val _floatStr by lazy {
         PyString(wrapped.toString())
     }
 
     override fun getPyStr(): PyString = _floatStr
     override fun getPyRepr(): PyString = _floatStr
+
+    override var type: PyType
+        get() = PyFloatType
+        set(_) = error("Cannot set the type for this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyFloat.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyFloat.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyFloatType
 
 /**
@@ -33,5 +34,5 @@ class PyFloat(val wrapped: Double) : PyObject() {
 
     override var type: PyType
         get() = PyFloatType
-        set(_) = error("Cannot set the type for this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyInt.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyInt.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyIntType
 /**
  * Represents a Python int type. This internally wraps a long,
  */
-class PyInt(val wrappedInt: Long) : PyObject(PyIntType) {
+class PyInt(val wrappedInt: Long) : PyObject() {
 
     override fun getPyStr(): PyString = PyString(wrappedInt.toString())
 
@@ -38,4 +38,8 @@ class PyInt(val wrappedInt: Long) : PyObject(PyIntType) {
     override fun hashCode(): Int {
         return wrappedInt.hashCode()
     }
+
+    override var type: PyType
+        get() = PyIntType
+        set(_) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyInt.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyInt.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyIntType
 
 /**
@@ -41,5 +42,5 @@ class PyInt(val wrappedInt: Long) : PyObject() {
 
     override var type: PyType
         get() = PyIntType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyMethod.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyMethod.kt
@@ -28,7 +28,7 @@ import green.sailor.kython.interpreter.stack.StackFrame
 class PyMethod(
     val function: PyCallable,
     val instance: PyObject
-) : PyObject(PyMethodType), PyCallable {
+) : PyObject(), PyCallable {
 
     override fun runCallable(
         args: List<PyObject>,
@@ -55,4 +55,8 @@ class PyMethod(
     }
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = PyMethodType
+        set(_) = error("Cannot change the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyMethod.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyMethod.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.iface.PyCallableSignature
 import green.sailor.kython.interpreter.pyobject.types.PyMethodType
@@ -58,5 +59,5 @@ class PyMethod(
 
     override var type: PyType
         get() = PyMethodType
-        set(_) = error("Cannot change the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyNone.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyNone.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyNoneType
 
 /**
@@ -33,5 +34,5 @@ object PyNone : PyObject() {
 
     override var type: PyType
         get() = PyNoneType
-        set(_) = error("Cannot change the type of this value")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyNone.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyNone.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyNoneType
 /**
  * Represents the Python None.
  */
-object PyNone : PyObject(PyNoneType) {
+object PyNone : PyObject() {
 
     private val noneString =
         PyString("None")
@@ -30,4 +30,8 @@ object PyNone : PyObject(PyNoneType) {
     override fun getPyStr(): PyString = noneString
 
     override fun getPyRepr(): PyString = noneString
+
+    override var type: PyType
+        get() = PyNoneType
+        set(_) = error("Cannot change the type of this value")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyObject.kt
@@ -22,7 +22,6 @@ import green.sailor.kython.interpreter.functions.PyFunction
 import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.kyobject.KyMagicMethods
 import green.sailor.kython.interpreter.pyobject.types.PyRootObjectType
-import green.sailor.kython.interpreter.pyobject.types.PyRootType
 import green.sailor.kython.interpreter.throwKy
 
 // initialdict:
@@ -34,7 +33,7 @@ import green.sailor.kython.interpreter.throwKy
 /**
  * Represents a Python object. Examples include an int, strings, et cetera, or user-defined objects.
  */
-abstract class PyObject() {
+abstract class PyObject {
     companion object {
         /**
          * Wraps a primitive type into a PyObject.
@@ -66,10 +65,6 @@ abstract class PyObject() {
             get() = linkedMapOf()
     }
 
-    constructor(type: PyType) : this() {
-        this.type = type
-    }
-
     // internal attribs
 
     /**
@@ -80,7 +75,7 @@ abstract class PyObject() {
 
     // exposed attribs
     /** The type of this PyObject. */
-    open var type: PyType = PyRootType
+    abstract var type: PyType
 
     /** The parent types of this PyObject. Exposed as `__bases__`. */
     open val parentTypes = mutableListOf<PyType>(PyRootObjectType)

--- a/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyRootObjectType
 
 /**
@@ -36,5 +37,5 @@ class PyRootObjectInstance : PyObject() {
 
     override var type: PyType
         get() = PyRootObjectType
-        set(_) = error("Cannot change the type of this builtin")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyRootObjectType
 /**
  * Represents a root object instance (i.e. the result of doing `object()`).
  */
-class PyRootObjectInstance : PyObject(PyRootObjectType) {
+class PyRootObjectInstance : PyObject() {
     private val _cached: PyString
 
     init {
@@ -32,6 +32,9 @@ class PyRootObjectInstance : PyObject(PyRootObjectType) {
     }
 
     override fun getPyRepr(): PyString = getPyStr()
-
     override fun getPyStr(): PyString = _cached
+
+    override var type: PyType
+        get() = PyRootObjectType
+        set(_) = error("Cannot change the type of this builtin")
 }

--- a/src/main/kotlin/interpreter/pyobject/PySet.kt
+++ b/src/main/kotlin/interpreter/pyobject/PySet.kt
@@ -22,11 +22,15 @@ import green.sailor.kython.interpreter.pyobject.types.PySetType
 /**
  * Represents an ordered Python set.
  */
-class PySet(val wrappedSet: LinkedHashSet<PyObject>) : PyObject(PySetType) {
+class PySet(val wrappedSet: LinkedHashSet<PyObject>) : PyObject() {
 
     override fun getPyStr(): PyString = PyString(
-        wrappedSet.joinToString(", ") { it.getPyRepr().wrappedString }
+        "{" + wrappedSet.joinToString(", ") { it.getPyRepr().wrappedString } + "}"
     )
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = PySetType
+        set(_) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PySet.kt
+++ b/src/main/kotlin/interpreter/pyobject/PySet.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PySetType
 
 /**
@@ -32,5 +33,5 @@ class PySet(val wrappedSet: LinkedHashSet<PyObject>) : PyObject() {
 
     override var type: PyType
         get() = PySetType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyString.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyString.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyStringType
 /**
  * Represents a Python string. This wraps a regular JVM string.
  */
-class PyString(val wrappedString: String) : PyObject(PyStringType) {
+class PyString(val wrappedString: String) : PyObject() {
     companion object {
         // some common strings
         val UNPRINTABLE =
@@ -46,4 +46,8 @@ class PyString(val wrappedString: String) : PyObject(PyStringType) {
     override fun hashCode(): Int {
         return wrappedString.hashCode()
     }
+
+    override var type: PyType
+        get() = PyStringType
+        set(_) = error("Cannot get the type of this value")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyString.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyString.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyStringType
 
 /**
@@ -49,5 +50,5 @@ class PyString(val wrappedString: String) : PyObject() {
 
     override var type: PyType
         get() = PyStringType
-        set(_) = error("Cannot get the type of this value")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyTuple.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyTuple.kt
@@ -40,5 +40,5 @@ class PyTuple(val subobjects: List<PyObject>) : PyObject() {
 
     override var type: PyType
         get() = PyTupleType
-        set(value) = error("Cannot set the type of this object")
+        set(_) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyTuple.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyTuple.kt
@@ -22,7 +22,7 @@ import green.sailor.kython.interpreter.pyobject.types.PyTupleType
 /**
  * Represents a python tuple of objects. This is a fixed-size immutable container for other PyObject.
  */
-class PyTuple(val subobjects: List<PyObject>) : PyObject(PyTupleType) {
+class PyTuple(val subobjects: List<PyObject>) : PyObject() {
     companion object {
         /**
          * Represents the empty tuple.
@@ -37,4 +37,8 @@ class PyTuple(val subobjects: List<PyObject>) : PyObject(PyTupleType) {
     }
 
     override fun getPyRepr(): PyString = getPyStr()
+
+    override var type: PyType
+        get() = PyTupleType
+        set(value) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyTuple.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyTuple.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.pyobject.types.PyTupleType
 
 /**
@@ -40,5 +41,5 @@ class PyTuple(val subobjects: List<PyObject>) : PyObject() {
 
     override var type: PyType
         get() = PyTupleType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyType.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyType.kt
@@ -17,6 +17,7 @@
  */
 package green.sailor.kython.interpreter.pyobject
 
+import green.sailor.kython.interpreter.Exceptions
 import green.sailor.kython.interpreter.functions.PyBuiltinFunction
 import green.sailor.kython.interpreter.iface.ArgType
 import green.sailor.kython.interpreter.iface.PyCallable
@@ -68,5 +69,5 @@ abstract class PyType(val name: String) : PyObject(), PyCallable {
 
     override var type: PyType
         get() = PyRootType
-        set(_) = error("Cannot set the type of this object")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/PyType.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyType.kt
@@ -22,6 +22,7 @@ import green.sailor.kython.interpreter.iface.ArgType
 import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.iface.PyCallableSignature
 import green.sailor.kython.interpreter.kyobject.KyMagicMethods
+import green.sailor.kython.interpreter.pyobject.types.PyRootType
 import green.sailor.kython.interpreter.stack.StackFrame
 
 /**
@@ -64,4 +65,8 @@ abstract class PyType(val name: String) : PyObject(), PyCallable {
     override fun getPyStr(): PyString = _pyString
 
     override fun getPyRepr(): PyString = _pyString
+
+    override var type: PyType
+        get() = PyRootType
+        set(value) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/PyType.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyType.kt
@@ -68,5 +68,5 @@ abstract class PyType(val name: String) : PyObject(), PyCallable {
 
     override var type: PyType
         get() = PyRootType
-        set(value) = error("Cannot set the type of this object")
+        set(_) = error("Cannot set the type of this object")
 }

--- a/src/main/kotlin/interpreter/pyobject/types/PyRootObjectType.kt
+++ b/src/main/kotlin/interpreter/pyobject/types/PyRootObjectType.kt
@@ -33,8 +33,6 @@ object PyRootObjectType : PyType("object") {
         return PyRootObjectInstance()
     }
 
-    override var type = this as PyType // no clue why this needs casting
-
     override val signature: PyCallableSignature = PyCallableSignature.EMPTY
 
     // prevents errors

--- a/src/main/kotlin/interpreter/pyobject/types/PyRootType.kt
+++ b/src/main/kotlin/interpreter/pyobject/types/PyRootType.kt
@@ -42,5 +42,5 @@ object PyRootType : PyType("type") {
 
     override var type: PyType
         get() = this
-        set(_) = error("Cannot set the type of this function")
+        set(_) = Exceptions.invalidClassSet(this)
 }

--- a/src/main/kotlin/interpreter/pyobject/types/PyRootType.kt
+++ b/src/main/kotlin/interpreter/pyobject/types/PyRootType.kt
@@ -40,5 +40,7 @@ object PyRootType : PyType("type") {
             .throwKy()
     }
 
-    override var type: PyType = PyRootType
+    override var type: PyType
+        get() = this
+        set(_) = error("Cannot set the type of this function")
 }


### PR DESCRIPTION
This makes it a getter, because a) that's what it was
compiled down to anyway, and b) types are singletons so they don't
need to be assigned to the field.