### PR TITLE
Better magic methods:

### DIFF
--- a/src/main/kotlin/interpreter/Builtins.kt
+++ b/src/main/kotlin/interpreter/Builtins.kt
@@ -29,6 +29,7 @@ import green.sailor.kython.interpreter.pyobject.types.*
 @Suppress("MemberVisibilityCanBePrivate")
 object Builtins {
     val PRINT = PrintBuiltinFunction()
+    val REPR = ReprBuiltinFunction()
     val LOCALS = LocalsBuiltinFunction()
     val DIR = DirBuiltinFunction()
     val ITER = IterBuiltinFunction()
@@ -54,6 +55,7 @@ object Builtins {
     /** The PyDict map of builtins. */
     val BUILTINS_MAP = linkedMapOf(
         "print" to PRINT,
+        "repr" to REPR,
         "locals" to LOCALS,
         "dir" to DIR,
         "iter" to ITER,

--- a/src/main/kotlin/interpreter/functions/PrintBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PrintBuiltinFunction.kt
@@ -31,7 +31,7 @@ class PrintBuiltinFunction : PyBuiltinFunction("print") {
         // todo: more args
 
         val args = kwargs["args"] as PyTuple
-        val result = args.subobjects.joinToString(" ") { it.getPyRepr().wrappedString }
+        val result = args.subobjects.joinToString(" ") { it.pyGetStr().wrappedString }
 
         println(result)
         return PyNone

--- a/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyBuiltinFunction.kt
@@ -56,9 +56,9 @@ abstract class PyBuiltinFunction(val name: String) : PyFunction() {
         }
     }
 
-    override fun getPyStr(): PyString = PyString("<built-in function $name>")
+    override fun kyDefaultStr(): PyString = PyString("<built-in function $name>")
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     /**
      * Called when the function is called from within a stack frame.

--- a/src/main/kotlin/interpreter/functions/PyUserFunction.kt
+++ b/src/main/kotlin/interpreter/functions/PyUserFunction.kt
@@ -78,9 +78,9 @@ class PyUserFunction(codeObject: KyCodeObject) : PyFunction() {
 
     override fun createFrame(): StackFrame = UserCodeStackFrame(this)
 
-    override fun getPyStr(): PyString = PyString("<user function ${code.codename}>")
+    override fun kyDefaultStr(): PyString = PyString("<user function ${code.codename}>")
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = PyUserFunctionType

--- a/src/main/kotlin/interpreter/functions/ReprBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/ReprBuiltinFunction.kt
@@ -15,24 +15,21 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-package green.sailor.kython.interpreter.pyobject
 
-import green.sailor.kython.interpreter.Exceptions
-import green.sailor.kython.interpreter.pyobject.types.PyFloatType
+package green.sailor.kython.interpreter.functions
+
+import green.sailor.kython.interpreter.iface.ArgType
+import green.sailor.kython.interpreter.iface.PyCallableSignature
+import green.sailor.kython.interpreter.pyobject.PyObject
 
 /**
- * Represents a Python float. This wraps a kotlin Double (CPython wraps a C double,
- * so we're consistent there).
+ * Represents the repr() builtin.
  */
-class PyFloat(val wrapped: Double) : PyObject() {
-    private val _floatStr by lazy {
-        PyString(wrapped.toString())
+class ReprBuiltinFunction : PyBuiltinFunction("repr") {
+    override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
+        val obb = kwargs["obb"] ?: error("Built-in signature mismatch")
+        return obb.pyGetRepr()
     }
 
-    override fun kyDefaultStr(): PyString = _floatStr
-    override fun kyDefaultRepr(): PyString = _floatStr
-
-    override var type: PyType
-        get() = PyFloatType
-        set(_) = Exceptions.invalidClassSet(this)
+    override val signature: PyCallableSignature = PyCallableSignature("obb" to ArgType.POSITIONAL)
 }

--- a/src/main/kotlin/interpreter/functions/ReprBuiltinFunction.kt
+++ b/src/main/kotlin/interpreter/functions/ReprBuiltinFunction.kt
@@ -15,7 +15,6 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 package green.sailor.kython.interpreter.functions
 
 import green.sailor.kython.interpreter.iface.ArgType

--- a/src/main/kotlin/interpreter/functions/magic/ObjectDir.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectDir.kt
@@ -29,6 +29,6 @@ object ObjectDir : PyBuiltinFunction("<object.__dir__>") {
 
     override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
         val obb = kwargs["self"] ?: error("Built-in signature mismatch!")
-        return obb.pyDefaultDir()
+        return obb.kyDefaultDir()
     }
 }

--- a/src/main/kotlin/interpreter/functions/magic/ObjectRepr.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectRepr.kt
@@ -15,7 +15,6 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 package green.sailor.kython.interpreter.functions.magic
 
 import green.sailor.kython.interpreter.functions.PyBuiltinFunction

--- a/src/main/kotlin/interpreter/functions/magic/ObjectRepr.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectRepr.kt
@@ -15,24 +15,21 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-package green.sailor.kython.interpreter.pyobject
 
-import green.sailor.kython.interpreter.Exceptions
-import green.sailor.kython.interpreter.pyobject.types.PyFloatType
+package green.sailor.kython.interpreter.functions.magic
+
+import green.sailor.kython.interpreter.functions.PyBuiltinFunction
+import green.sailor.kython.interpreter.iface.PyCallableSignature
+import green.sailor.kython.interpreter.pyobject.PyObject
 
 /**
- * Represents a Python float. This wraps a kotlin Double (CPython wraps a C double,
- * so we're consistent there).
+ * Represents the default object __repr__.
  */
-class PyFloat(val wrapped: Double) : PyObject() {
-    private val _floatStr by lazy {
-        PyString(wrapped.toString())
+object ObjectRepr : PyBuiltinFunction("<object __repr__>") {
+    override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
+        val self = kwargs["self"] ?: error("Built-in signature mismatch")
+        return self.kyDefaultRepr()
     }
 
-    override fun kyDefaultStr(): PyString = _floatStr
-    override fun kyDefaultRepr(): PyString = _floatStr
-
-    override var type: PyType
-        get() = PyFloatType
-        set(_) = Exceptions.invalidClassSet(this)
+    override val signature: PyCallableSignature = PyCallableSignature.EMPTY_METHOD
 }

--- a/src/main/kotlin/interpreter/functions/magic/ObjectStr.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectStr.kt
@@ -15,7 +15,6 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 package green.sailor.kython.interpreter.functions.magic
 
 import green.sailor.kython.interpreter.functions.PyBuiltinFunction

--- a/src/main/kotlin/interpreter/functions/magic/ObjectStr.kt
+++ b/src/main/kotlin/interpreter/functions/magic/ObjectStr.kt
@@ -15,24 +15,21 @@
  * along with kython.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-package green.sailor.kython.interpreter.pyobject
 
-import green.sailor.kython.interpreter.Exceptions
-import green.sailor.kython.interpreter.pyobject.types.PyFloatType
+package green.sailor.kython.interpreter.functions.magic
+
+import green.sailor.kython.interpreter.functions.PyBuiltinFunction
+import green.sailor.kython.interpreter.iface.PyCallableSignature
+import green.sailor.kython.interpreter.pyobject.PyObject
 
 /**
- * Represents a Python float. This wraps a kotlin Double (CPython wraps a C double,
- * so we're consistent there).
+ * Represents the default object str.
  */
-class PyFloat(val wrapped: Double) : PyObject() {
-    private val _floatStr by lazy {
-        PyString(wrapped.toString())
+object ObjectStr : PyBuiltinFunction("<object __str__>") {
+    override fun callFunction(kwargs: Map<String, PyObject>): PyObject {
+        val self = kwargs["self"]!!
+        return self.kyDefaultStr()
     }
 
-    override fun kyDefaultStr(): PyString = _floatStr
-    override fun kyDefaultRepr(): PyString = _floatStr
-
-    override var type: PyType
-        get() = PyFloatType
-        set(_) = Exceptions.invalidClassSet(this)
+    override val signature: PyCallableSignature = PyCallableSignature.EMPTY_METHOD
 }

--- a/src/main/kotlin/interpreter/kyobject/KyMagicMethods.kt
+++ b/src/main/kotlin/interpreter/kyobject/KyMagicMethods.kt
@@ -19,6 +19,8 @@ package green.sailor.kython.interpreter.kyobject
 
 import green.sailor.kython.interpreter.functions.magic.ObjectDir
 import green.sailor.kython.interpreter.functions.magic.ObjectGetattribute
+import green.sailor.kython.interpreter.functions.magic.ObjectRepr
+import green.sailor.kython.interpreter.functions.magic.ObjectStr
 import green.sailor.kython.interpreter.iface.PyCallable
 import green.sailor.kython.interpreter.pyobject.PyNone
 import green.sailor.kython.interpreter.pyobject.PyObject
@@ -34,12 +36,20 @@ class KyMagicMethods(val bound: Boolean) {
     // TODO: This is very sparse right now.
 
     // == builtins with defaults == //
-    // these will *never* be null.
 
     // __getattribute__
-    val tpGetAttribute: PyCallable = ObjectGetattribute
+    var tpGetAttribute: PyCallable = ObjectGetattribute
     // __dir__
-    val tpDir: PyCallable = ObjectDir
+    var tpDir: PyCallable = ObjectDir
+
+    // __str__
+    var tpStr: PyCallable? = ObjectStr
+
+    // __repr__
+    val tpRepr: PyCallable? = ObjectRepr
+
+    // == builtins without defaults == //
+    // these can be null.
 
     /**
      * Turns a magic method name into a magic method.
@@ -48,6 +58,8 @@ class KyMagicMethods(val bound: Boolean) {
         return when (name) {
             "__getattribute__" -> tpGetAttribute
             "__dir__" -> tpDir
+            "__str__" -> tpStr
+            "__repr__" -> tpRepr
             else -> null
         }
     }

--- a/src/main/kotlin/interpreter/pyobject/PyBool.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBool.kt
@@ -38,6 +38,6 @@ class PyBool private constructor(val wrapped: Boolean) : PyObject() {
         get() = PyBoolType
         set(_) = Exceptions.invalidClassSet(this)
 
-    override fun getPyStr(): PyString = if (wrapped) cachedTrueString else cachedFalseString
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultStr(): PyString = if (wrapped) cachedTrueString else cachedFalseString
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 }

--- a/src/main/kotlin/interpreter/pyobject/PyBytes.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyBytes.kt
@@ -24,14 +24,14 @@ import green.sailor.kython.interpreter.pyobject.types.PyBytesType
  * Represents a Python bytes object. This wraps a regular JVM ByteArray.
  */
 class PyBytes(val wrapped: ByteArray) : PyObject() {
-    override fun getPyStr(): PyString = getPyRepr()
+    override fun kyDefaultStr(): PyString = kyDefaultRepr()
 
-    override fun getPyRepr(): PyString {
+    override fun kyDefaultRepr(): PyString {
         val inner = PyString(wrapped.joinToString("") {
             if (it in 32..126) it.toChar().toString()
             else "\\x" + it.toUByte().toString(16).padStart(2, '0')
         })
-        return PyString("b${inner.getPyRepr().wrappedString}")
+        return PyString("b${inner.pyGetRepr().wrappedString}")
     }
 
     override var type: PyType

--- a/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyCodeObject.kt
@@ -23,11 +23,11 @@ import green.sailor.kython.interpreter.kyobject.KyCodeObject
  * Represents a code object. Wraps a KyCodeObject, but exposes it to Python.
  */
 class PyCodeObject(val wrappedCodeObject: KyCodeObject) : PyObject() {
-    override fun getPyStr(): PyString {
+    override fun kyDefaultStr(): PyString {
         return PyString("<code object ${wrappedCodeObject.codename}>")
     }
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = TODO("not implemented")

--- a/src/main/kotlin/interpreter/pyobject/PyDict.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyDict.kt
@@ -40,14 +40,14 @@ class PyDict(val items: LinkedHashMap<out PyObject, out PyObject>) : PyObject() 
         }
     }
 
-    override fun getPyStr(): PyString {
+    override fun kyDefaultStr(): PyString {
         val joined = items.entries.joinToString {
-            it.key.getPyRepr().wrappedString + ": " + it.value.getPyRepr().wrappedString
+            it.key.pyGetRepr().wrappedString + ": " + it.value.pyGetRepr().wrappedString
         }
         return PyString("{$joined}")
     }
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = PyDictType

--- a/src/main/kotlin/interpreter/pyobject/PyException.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyException.kt
@@ -68,7 +68,7 @@ abstract class PyException(val args: PyTuple) : PyObject() {
             return object : PyExceptionType(name) {
                 override fun newInstance(kwargs: Map<String, PyObject>): PyObject {
                     val args = kwargs["args"] as PyTuple
-                    val strings = args.subobjects.map { it.getPyStr() }
+                    val strings = args.subobjects.map { it.pyGetStr() }
 
                     return interpreterGetExceptionInstance(strings)
                 }
@@ -102,12 +102,12 @@ abstract class PyException(val args: PyTuple) : PyObject() {
         exceptionFrames = frames
     }
 
-    override fun getPyStr(): PyString {
+    override fun kyDefaultStr(): PyString {
         require(type is PyExceptionType) { "Type of exception was not PyExceptionType!" }
         TODO()
     }
 
-    override fun getPyRepr(): PyString {
+    override fun kyDefaultRepr(): PyString {
         TODO("not implemented")
     }
 }

--- a/src/main/kotlin/interpreter/pyobject/PyInt.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyInt.kt
@@ -25,9 +25,9 @@ import green.sailor.kython.interpreter.pyobject.types.PyIntType
  */
 class PyInt(val wrappedInt: Long) : PyObject() {
 
-    override fun getPyStr(): PyString = PyString(wrappedInt.toString())
+    override fun kyDefaultStr(): PyString = PyString(wrappedInt.toString())
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/src/main/kotlin/interpreter/pyobject/PyMethod.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyMethod.kt
@@ -43,7 +43,7 @@ class PyMethod(
 
     override val signature: PyCallableSignature = function.signature
 
-    override fun getPyStr(): PyString {
+    override fun kyDefaultStr(): PyString {
         val output = buildString {
             append("<method '")
             append((function as PyObject).getPyStringSafe().wrappedString)
@@ -55,7 +55,7 @@ class PyMethod(
         return PyString(output)
     }
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = PyMethodType

--- a/src/main/kotlin/interpreter/pyobject/PyNone.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyNone.kt
@@ -28,9 +28,9 @@ object PyNone : PyObject() {
     private val noneString =
         PyString("None")
 
-    override fun getPyStr(): PyString = noneString
+    override fun kyDefaultStr(): PyString = noneString
 
-    override fun getPyRepr(): PyString = noneString
+    override fun kyDefaultRepr(): PyString = noneString
 
     override var type: PyType
         get() = PyNoneType

--- a/src/main/kotlin/interpreter/pyobject/PyObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyObject.kt
@@ -146,7 +146,6 @@ abstract class PyObject {
      */
     abstract fun kyDefaultRepr(): PyString
 
-
     // ==== MAGIC METHODS: INTERFACES ====
     // All these functions are delegates to the real magic methods.
     // This is shorter than using ``someObb.magicSlots.tpMethod.runCallable(...)``

--- a/src/main/kotlin/interpreter/pyobject/PyObject.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyObject.kt
@@ -176,7 +176,7 @@ abstract class PyObject {
 
         val result = bindMagicMethod(strFn).runCallable(listOf())
         if (result !is PyString) {
-            TODO("error")
+            Exceptions.TYPE_ERROR("__str__ did not return a string").throwKy()
         }
         return result
     }
@@ -190,7 +190,7 @@ abstract class PyObject {
 
         val result = bindMagicMethod(strFn).runCallable(listOf())
         if (result !is PyString) {
-            TODO("error")
+            Exceptions.TYPE_ERROR("__repr__ did not return a string").throwKy()
         }
         return result
     }

--- a/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyRootObjectInstance.kt
@@ -32,8 +32,8 @@ class PyRootObjectInstance : PyObject() {
         _cached = if (ooEnabled) PyString("[object Object]") else PyString("<object object>")
     }
 
-    override fun getPyRepr(): PyString = getPyStr()
-    override fun getPyStr(): PyString = _cached
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
+    override fun kyDefaultStr(): PyString = _cached
 
     override var type: PyType
         get() = PyRootObjectType

--- a/src/main/kotlin/interpreter/pyobject/PySet.kt
+++ b/src/main/kotlin/interpreter/pyobject/PySet.kt
@@ -25,11 +25,11 @@ import green.sailor.kython.interpreter.pyobject.types.PySetType
  */
 class PySet(val wrappedSet: LinkedHashSet<PyObject>) : PyObject() {
 
-    override fun getPyStr(): PyString = PyString(
-        "{" + wrappedSet.joinToString(", ") { it.getPyRepr().wrappedString } + "}"
+    override fun kyDefaultStr(): PyString = PyString(
+        "{" + wrappedSet.joinToString(", ") { it.pyGetRepr().wrappedString } + "}"
     )
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = PySetType

--- a/src/main/kotlin/interpreter/pyobject/PyString.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyString.kt
@@ -30,8 +30,8 @@ class PyString(val wrappedString: String) : PyObject() {
             PyString("<unprintable>")
     }
 
-    override fun getPyStr(): PyString = this
-    override fun getPyRepr(): PyString = PyString("'$wrappedString'")
+    override fun kyDefaultStr(): PyString = this
+    override fun kyDefaultRepr(): PyString = PyString("'$wrappedString'")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {

--- a/src/main/kotlin/interpreter/pyobject/PyTuple.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyTuple.kt
@@ -31,13 +31,13 @@ class PyTuple(val subobjects: List<PyObject>) : PyObject() {
         val EMPTY = PyTuple(listOf())
     }
 
-    override fun getPyStr(): PyString {
+    override fun kyDefaultStr(): PyString {
         return PyString("(" + subobjects.joinToString {
-            it.getPyRepr().wrappedString
+            it.pyGetRepr().wrappedString
         } + ")")
     }
 
-    override fun getPyRepr(): PyString = getPyStr()
+    override fun kyDefaultRepr(): PyString = kyDefaultStr()
 
     override var type: PyType
         get() = PyTupleType

--- a/src/main/kotlin/interpreter/pyobject/PyType.kt
+++ b/src/main/kotlin/interpreter/pyobject/PyType.kt
@@ -63,9 +63,9 @@ abstract class PyType(val name: String) : PyObject(), PyCallable {
     }
 
     // default impls
-    override fun getPyStr(): PyString = _pyString
+    override fun kyDefaultStr(): PyString = _pyString
 
-    override fun getPyRepr(): PyString = _pyString
+    override fun kyDefaultRepr(): PyString = _pyString
 
     override var type: PyType
         get() = PyRootType

--- a/src/main/kotlin/interpreter/pyobject/types/PyStringType.kt
+++ b/src/main/kotlin/interpreter/pyobject/types/PyStringType.kt
@@ -30,7 +30,7 @@ import green.sailor.kython.interpreter.throwKy
 object PyStringType : PyType("str") {
     override fun newInstance(kwargs: Map<String, PyObject>): PyObject {
         val arg = kwargs["x"]!!
-        return arg.getPyStr()
+        return arg.pyGetStr()
     }
 
     override val signature: PyCallableSignature by lazy {

--- a/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
+++ b/src/main/kotlin/interpreter/stack/UserCodeStackFrame.kt
@@ -402,7 +402,8 @@ class UserCodeStackFrame(val function: PyUserFunction) : StackFrame() {
     fun importStar(arg: Byte) {
         val module = stack.pop()
 
-        module.pyDefaultDir().internalDict.forEach {
+        // TODO: Use the real __dir__
+        module.kyDefaultDir().internalDict.forEach {
             if (!it.key.startsWith("_")) {
                 locals[it.key] = it.value
             }


### PR DESCRIPTION
1) getPyStr -> pyGetStr, same for repr
2) builtin impls of str is now kyDefaultStr
3) expose __str__/__repr__ properly
4) add repr() builtin
5) fix long-standing print over str bug